### PR TITLE
Set Central Timezone for plotting

### DIFF
--- a/sensorpush.py
+++ b/sensorpush.py
@@ -109,6 +109,8 @@ class SensorPushClient:
 class SensorPushGUI(tk.Tk):
     def __init__(self):
         super().__init__()
+        import matplotlib
+        matplotlib.rcParams["timezone"] = "US/Central"
         self.title("SensorPush – % Temps < 64 °F (24 h)")
         # Let the window expand naturally so the optional layout overlay
         # is fully visible. Use a minimum size to keep the base UI usable.


### PR DESCRIPTION
## Summary
- configure matplotlib's timezone so charts show Central Time

## Testing
- `python -m py_compile sensorpush.py`


------
https://chatgpt.com/codex/tasks/task_e_6852db6c10f883269484d98be4c6caa5